### PR TITLE
ユーザー検索をインクリメンタルサーチ化

### DIFF
--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -1,0 +1,62 @@
+$(function(){
+
+// ユーザー検索時に表示されるユーザー名と追加ボタンのHTML
+  function appendList(user) {
+    var html =
+      `<div class="chat-group-user clearfix">
+        <p class="chat-group-user__name">
+          ${user.name}</p>
+        <a class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${user.id}" data-user-name="${user.name}">追加
+        </a>
+      </div>`;
+    $('#user-search-result').append(html)
+  }
+
+// 追加ボタンクリック後のユーザー名と削除ボタンのHTML
+  function buildMemberHTML(id, name) {
+    var html =
+    `<div class="chat-group-user clearfix" id=chat-group-user-${id}>
+      <input type="hidden" name="group[user_ids][]" value="${id}">
+      <p class="chat-group-user__name">${name}</p>
+      <a class="user-search-remove chat-group-user__btn chat-group-user__btn--remove" data-user-id="${id}">削除</a>
+    </div>`;
+    return html
+  }
+
+// フォームに入力した瞬間に発動。コントローラーにjson形式で入力内容を送る。
+  $(document).on('keyup', '.chat-group-form__input', function(e){
+    e.preventDefault();
+    var input = $.trim($(this).val());
+    $.ajax({
+      type: 'GET',
+      url: '/users/search',
+      data: ('keyword=' + input),
+      processData: false,
+      contentType: false,
+      dataType: 'json'
+    })
+
+//コントローラーからデータが無事に戻ってきたら発動。ユーザーリストを作成する。dataにはコントローラの@usersが入っている。
+    .done(function(data){
+      $('#user-search-result').find('.chat-group-user').remove();
+      $(data).each(function(i, user){
+        appendList(user)
+      });
+    })
+  });
+
+//追加ボタンをクリックしたら発動。
+  $("#user-search-result").on('click', '.chat-group-user__btn--add', function(){
+    var id = $(this).data('userId');
+    var name = $(this).data('userName');
+    var insertHTML = buildMemberHTML(id, name);
+    $('#chat-group-users').append(insertHTML);
+    $(this).parent('.chat-group-user').remove();
+  });
+
+  // 削除ボタンをクリックしたら発動。
+  $('#chat-group-users').on('click', '.user-search-remove', function() {
+    var id = $(this).data('userId');
+    $(`#chat-group-user-${id}`).remove();
+  })
+});

--- a/app/assets/javascripts/group.js
+++ b/app/assets/javascripts/group.js
@@ -39,22 +39,23 @@ $(function(){
 //コントローラーからデータが無事に戻ってきたら発動。ユーザーリストを作成する。dataにはコントローラの@usersが入っている。
     .done(function(data){
       $('#user-search-result').find('.chat-group-user').remove();
-      $(data).each(function(i, user){
+      $(data.members).each(function(i, user){
         appendList(user)
       });
-    })
+    });
   });
 
 //追加ボタンをクリックしたら発動。
   $("#user-search-result").on('click', '.chat-group-user__btn--add', function(){
-    var id = $(this).data('userId');
-    var name = $(this).data('userName');
+    var $chatGroupUserBtnAdd = $('.chat-group-user__btn--add');
+    var id = $chatGroupUserBtnAdd.data('userId');
+    var name = $chatGroupUserBtnAdd.data('userName');
     var insertHTML = buildMemberHTML(id, name);
     $('#chat-group-users').append(insertHTML);
-    $(this).parent('.chat-group-user').remove();
+    $chatGroupUserBtnAdd.parent('.chat-group-user').remove();
   });
 
-  // 削除ボタンをクリックしたら発動。
+// 削除ボタンをクリックしたら発動。
   $('#chat-group-users').on('click', '.user-search-remove', function() {
     var id = $(this).data('userId');
     $(`#chat-group-user-${id}`).remove();

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -13,7 +13,7 @@ class UsersController < ApplicationController
   def search
     @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(name: current_user.name)
     respond_to do |format|
-      format.json { render 'groups/new', json: @users }
+      format.json { render 'search.json.jbuilder', handlers: :jbuilder }
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,13 @@ class UsersController < ApplicationController
     redirect_to :root
   end
 
+  def search
+    @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(name: current_user.name)
+    respond_to do |format|
+      format.json { render 'groups/new', json: @users }
+    end
+  end
+
   private
   def user_params
     params.require(:user).permit(:name, :email)

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -11,7 +11,7 @@
       .chat-group-form__label
         = f.label :users, 'チャットメンバーの追加'
     .chat-group-form__field--right
-      %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}
+      = f.text_field :users, value: "", class: 'chat-group-form__input', id: 'user-search-field', placeholder: '追加したいユーザー名を入力してください'
       #user-search-result
 
   / チェックボックス式のメンバー追加

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -9,12 +9,31 @@
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       .chat-group-form__label
-        = f.label :users, 'チャットメンバー'
+        = f.label :users, 'チャットメンバーの追加'
     .chat-group-form__field--right
-      .chat-group-form__search.clearfix
-        #user-search-field.chat-group-form__input
-          = f.collection_check_boxes(:user_ids, User.all, :id, :name)
-    #user-search-result
+      %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}
+      #user-search-result
+
+  / チェックボックス式のメンバー追加
+  / .chat-group-form__field.clearfix
+  /   .chat-group-form__field--left
+  /     .chat-group-form__label
+  /       = f.label :users, 'チャットメンバーの追加'
+  /   .chat-group-form__field--right
+  /     .chat-group-form__search.clearfix
+  /       #user-search-field.chat-group-form__input
+  /         = f.collection_check_boxes(:user_ids, User.all, :id, :name)
+
+  .chat-group-form__field.clearfix
+    .chat-group-form__field--left
+      .chat-group-form__label
+        = f.label '参加メンバー'
+    .chat-group-form__field--right
+      #chat-group-users
+        .chat-group-user.clearfix
+          %p.chat-group-user__name
+            = current_user.name
+
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -11,15 +11,3 @@
           = message
 
   = render partial: "groups/form", locals: { group: @group }
-
-/ この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
-/
-  <div class='chat-group-form__field--left'>
-  <label class="chat-group-form__label" for="chat_group_チャットメンバーを追加">チャットメンバーを追加</label>
-  </div>
-  <div class='chat-group-form__field--right'>
-  <div class='chat-group-form__search clearfix'>
-  <input class='chat-group-form__input' id='user-search-field' placeholder='追加したいユーザー名を入力してください' type='text'>
-  </div>
-  <div id='user-search-result'></div>
-  </div>

--- a/app/views/users/search.json.jbuilder
+++ b/app/views/users/search.json.jbuilder
@@ -1,0 +1,4 @@
+json.members @users do |user|
+  json.name user.name
+  json.id user.id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,13 @@
 Rails.application.routes.draw do
   root 'groups#index'
   devise_for :users
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:edit, :update] do
+    collection do
+      get 'search'
+    end
+  end
   resources :groups, except: [:destroy, :show] do
     resources :messages, only: [:index, :create]
   end
-  get 'users/search' => 'users#search'
+
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,5 @@ Rails.application.routes.draw do
   resources :groups, except: [:destroy, :show] do
     resources :messages, only: [:index, :create]
   end
+  get 'users/search' => 'users#search'
 end


### PR DESCRIPTION
# WHAT
グループ作成の際のユーザー検索をインクリメンタルサーチ化。
まずはインクリメンタルサーチとメンバの追加/削除を機能させる。
# WHY
ユーザー検索で入力のたびごとに即座に候補を表示させることで、ユーザー体験を向上させることが期待できるため。